### PR TITLE
handling failure of a module in Communication

### DIFF
--- a/src/main/java/fmfi/dalekohlad/Communication/Communication.java
+++ b/src/main/java/fmfi/dalekohlad/Communication/Communication.java
@@ -79,7 +79,7 @@ public class Communication {
                 reconnect();
             }
             catch (Exception e) {
-                lgr.error("Failed to read data, repeating...", e);
+                lgr.error("Failed to read data, repeating...");
                 sleep(1000);
             }
         }

--- a/src/main/java/fmfi/dalekohlad/Communication/Communication.java
+++ b/src/main/java/fmfi/dalekohlad/Communication/Communication.java
@@ -48,12 +48,21 @@ public class Communication {
         }
     }
 
+    private static void informModule(GUIModule mod, JsonObject jo) {
+        try {
+            mod.update(jo);
+        }
+        catch (Exception e) {
+            lgr.error(String.format("Update of module %s failed:", mod.getClass().getName()));
+        }
+    }
+
     private static void processUpdate(String data) {
         if (data.startsWith("{")) {
             JsonReader reader = new JsonReader(new StringReader(data.trim()));
             reader.setLenient(true);
             JsonObject json_object = JsonParser.parseReader(reader).getAsJsonObject();
-            modules.forEach(x -> x.update(json_object));
+            modules.forEach(x -> informModule(x, json_object));
         }
         else if (!data.equals("")) {
             Operations.add(data);
@@ -70,7 +79,7 @@ public class Communication {
                 reconnect();
             }
             catch (Exception e) {
-                lgr.error("Failed to read data, repeating...");
+                lgr.error("Failed to read data, repeating...", e);
                 sleep(1000);
             }
         }


### PR DESCRIPTION
single module raising an exception could interrupt the connection with irrelevant error "Failed to read data, repeating...", now we log the relevant error instead and continue